### PR TITLE
Patch a faulty line on cached resource processor

### DIFF
--- a/lib/jsonapi/renderer/cached_resources_processor.rb
+++ b/lib/jsonapi/renderer/cached_resources_processor.rb
@@ -19,7 +19,7 @@ module JSONAPI
           cache_hash = cache_key_map(resources)
           processed_resources = @cache.fetch_multi(*cache_hash.keys) do |key|
             res, include, fields = cache_hash[key]
-            json = res.as_jsonapi(include: include, fields: fields).to_json
+            json = res.as_jsonapi(include: (include || Set.new), fields: fields).to_json
 
             JSONString.new(json)
           end


### PR DESCRIPTION
From some debug calls I saw that these are all instances of `Set` in case they're empty